### PR TITLE
fix disp{0,1} to be 7 bits

### DIFF
--- a/wtfpga-lab-solution/wtfpga.v
+++ b/wtfpga-lab-solution/wtfpga.v
@@ -13,7 +13,7 @@ module top(
     );
 
 //define wires and registers here
-	wire [7:0] disp0,disp1;
+	wire [6:0] disp0,disp1;
 	wire displayClock;
 	reg [7:0] storedValue;
 	wire [7:0] dispValue, sum, diff;

--- a/wtfpga/wtfpga.v
+++ b/wtfpga/wtfpga.v
@@ -13,7 +13,7 @@ module top(
     );
 
 //define wires and registers here
-	wire [7:0] disp0,disp1;
+	wire [6:0] disp0,disp1;
 	wire displayClock;
 	wire wire1, wire2;
 	


### PR DESCRIPTION
It's a 7 segment display and all other modules handles this correctly,
but the main file used 8 bits instead of 7. This can lead to warnings
when verifying the code.